### PR TITLE
fix: simple volume persistence

### DIFF
--- a/SetupDatabase.ps1
+++ b/SetupDatabase.ps1
@@ -64,9 +64,10 @@ if ($restartingInstance) {
         $sqlcmd = "DROP DATABASE IF EXISTS $databaseName"
         & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
 
-        $files = Get-ChildItem (Join-Path $volPath $databaseName) -File
-        $joinedFiles = $files.Name -join "'), (FILENAME = '$volPath\"
-        $sqlcmd = "CREATE DATABASE $databaseName ON (FILENAME = '$volPath\$joinedFiles') FOR ATTACH;"
+        $dbPath = (Join-Path $volPath $databaseName)
+        $files = Get-ChildItem $dbPath -File
+        $joinedFiles = $files.Name -join "'), (FILENAME = '$dbPath\"
+        $sqlcmd = "CREATE DATABASE $databaseName ON (FILENAME = '$dbPath\$joinedFiles') FOR ATTACH;"
         & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
     }
 } else {

--- a/SetupDatabase.ps1
+++ b/SetupDatabase.ps1
@@ -64,8 +64,8 @@ if ($restartingInstance) {
         $sqlcmd = "DROP DATABASE IF EXISTS $databaseName"
         & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
 
-        $files = Get-ChildItem (Join-Path $volPath '*\*') -File
-        $joinedFiles = $files -join "'), (FILENAME = '$volPath\"
+        $files = Get-ChildItem (Join-Path $volPath $databaseName) -File
+        $joinedFiles = $files.Name -join "'), (FILENAME = '$volPath\"
         $sqlcmd = "CREATE DATABASE $databaseName ON (FILENAME = '$volPath\$joinedFiles') FOR ATTACH;"
         & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
     }

--- a/SetupDatabase.ps1
+++ b/SetupDatabase.ps1
@@ -64,7 +64,7 @@ if ($restartingInstance) {
         $sqlcmd = "DROP DATABASE IF EXISTS $databaseName"
         & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
 
-        $files = Get-ChildItem $volPath -File
+        $files = Get-ChildItem (Join-Path $volPath '*\*') -File
         $joinedFiles = $files -join "'), (FILENAME = '$volPath\"
         $sqlcmd = "CREATE DATABASE $databaseName ON (FILENAME = '$volPath\$joinedFiles') FOR ATTACH;"
         & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd

--- a/SetupDatabase.ps1
+++ b/SetupDatabase.ps1
@@ -1,5 +1,4 @@
 $volPath = "$env:volPath"
-#$myPassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword)).Replace('"','""').Replace('''',''''''))
 
 if ($restartingInstance) {
 
@@ -18,14 +17,7 @@ if ($restartingInstance) {
 
         $dummy = new-object Microsoft.SqlServer.Management.SMO.Server
 
-        #$sqlcmd = "ALTER LOGIN sa with password='$myPassword',CHECK_POLICY = OFF;ALTER LOGIN sa ENABLE;"
-        #& sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
-
         $sqlConn = new-object Microsoft.SqlServer.Management.Common.ServerConnection
-        #$sqlConn.ServerInstance = "localhost"
-        #$sqlConn.LoginSecure = $false
-        #$sqlConn.Login = "sa"
-        #$sqlConn.Password = $myPassword
 
         $toCopy = @()
 

--- a/SetupDatabase.ps1
+++ b/SetupDatabase.ps1
@@ -1,5 +1,5 @@
 $volPath = "$env:volPath"
-$myPassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword)).Replace('"','""').Replace('''',''''''))
+#$myPassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecurePassword)).Replace('"','""').Replace('''',''''''))
 
 if ($restartingInstance) {
 
@@ -18,14 +18,14 @@ if ($restartingInstance) {
 
         $dummy = new-object Microsoft.SqlServer.Management.SMO.Server
 
-        $sqlcmd = "ALTER LOGIN sa with password='$myPassword',CHECK_POLICY = OFF;ALTER LOGIN sa ENABLE;"
-        & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
+        #$sqlcmd = "ALTER LOGIN sa with password='$myPassword',CHECK_POLICY = OFF;ALTER LOGIN sa ENABLE;"
+        #& sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
 
         $sqlConn = new-object Microsoft.SqlServer.Management.Common.ServerConnection
-        $sqlConn.ServerInstance = "localhost"
-        $sqlConn.LoginSecure = $false
-        $sqlConn.Login = "sa"
-        $sqlConn.Password = $myPassword
+        #$sqlConn.ServerInstance = "localhost"
+        #$sqlConn.LoginSecure = $false
+        #$sqlConn.Login = "sa"
+        #$sqlConn.Password = $myPassword
 
         $toCopy = @()
 


### PR DESCRIPTION
- Password is not needed for local connections, it also causes problems as `$SecurePassword` is not available on restart but only on the first start
- When starting for the first time the DB files are moved to e.g. `C:\myvol\CRONUS\foo.mdf` but the re-attach tried to find them on `C:\myvol\*`.